### PR TITLE
Fixed fetchAllSaved() method typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 	<li>Axel has 4 methods as of now, 
 		<ul>
 			<li><strong>.save()</strong></li>
-			<li><strong>.fetdhAllSaved()</strong></li>
+			<li><strong>.fetchAllSaved()</strong></li>
 			<li><strong>.contains()</strong></li>
 			<li><strong>.updateDatabase()</strong></li>
 		</ul>


### PR DESCRIPTION
From reading the code i found a typo with the method name in the readme